### PR TITLE
Calculate sales tax on a given shopping basket

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+Metrics/BlockLength:
+  Max: 80
+
+Metrics/LineLength:
+  Max: 185
+
+Metrics/MethodLength:
+  Max: 15
+
+AllCops:
+    NewCops: enable

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rspec/core/rake_task'
+require './lib/receipt'
+require './lib/line_item'
+require './lib/shopping_basket_parser'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: %w[run]
+
+desc 'Run all specs'
+task test: :spec
+
+desc 'Generate receipts'
+task :run do
+  Rake::Task['receipt1'].invoke
+  Rake::Task['receipt2'].invoke
+  Rake::Task['receipt3'].invoke
+end
+
+task :receipt1 do
+  shopping_basket1 = 'Quantity, Product, Price
+    1, book, 12.49
+    1, music cd, 14.99
+    1, chocolate bar, 0.85'
+
+  line_items = ShoppingBasketParser.new(shopping_basket1).parse
+  puts 'Receipt 1'
+  puts Receipt.new(line_items).formatted_output
+end
+
+task :receipt2 do
+  shopping_basket2 = 'Quantity, Product, Price
+    1, imported box of chocolates, 10.00
+    1, imported bottle of perfume, 47.50'
+
+  line_items = ShoppingBasketParser.new(shopping_basket2).parse
+  puts 'Receipt 2'
+  puts Receipt.new(line_items).formatted_output
+end
+
+task :receipt3 do
+  # not handling the case where the input is 'box of imported chocolates',
+  # whereas the output is 'imported box of chocolates'
+  shopping_basket3 = 'Quantity, Product, Price
+    1, imported bottle of perfume, 27.99
+    1, bottle of perfume, 18.99
+    1, packet of headache pills, 9.75
+    1, box of imported chocolates, 11.25'
+
+  line_items = ShoppingBasketParser.new(shopping_basket3).parse
+  puts 'Receipt 3'
+  puts Receipt.new(line_items).formatted_output
+end

--- a/gems.locked
+++ b/gems.locked
@@ -7,6 +7,7 @@ GEM
     parser (3.0.2.0)
       ast (~> 2.4.1)
     rainbow (3.0.0)
+    rake (13.0.6)
     regexp_parser (2.1.1)
     rexml (3.2.5)
     rspec (3.10.0)
@@ -22,13 +23,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.18.3)
+    rubocop (1.18.4)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 1.8.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.8.0)
@@ -40,6 +41,7 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
+  rake
   rspec
   rubocop
 

--- a/gems.locked
+++ b/gems.locked
@@ -1,0 +1,50 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    diff-lcs (1.4.4)
+    parallel (1.20.1)
+    parser (3.0.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.18.3)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.7.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.8.0)
+      parser (>= 3.0.1.1)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.0.0)
+
+PLATFORMS
+  x86_64-darwin-19
+
+DEPENDENCIES
+  rspec
+  rubocop
+
+RUBY VERSION
+   ruby 2.6.3p62
+
+BUNDLED WITH
+   2.2.24

--- a/gems.rb
+++ b/gems.rb
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+ruby '2.6.3'
+gem 'rspec'
+gem 'rubocop'

--- a/gems.rb
+++ b/gems.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 ruby '2.6.3'
+gem 'rake'
 gem 'rspec'
 gem 'rubocop'

--- a/lib/line_item.rb
+++ b/lib/line_item.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Calculate sales tax on a purchase
+class LineItem
+  TAX_RATE = 10
+  IMPORT_DUTY = 5
+  NON_TAXABLE = %w[book chocolate chocolates pills].freeze
+  IMPORTED = %w[imported].freeze
+
+  attr_reader :name, :quantity
+
+  def initialize(quantity, name, shelf_price)
+    @quantity = quantity
+    @name = name
+    @shelf_price = shelf_price
+    @cost = shelf_price * quantity
+  end
+
+  def total_sales_tax
+    round_up_to_nearest005(calculate_sales_tax + calculate_import_duty)
+  end
+
+  def total_cost
+    format('%.2f', @cost + total_sales_tax)
+  end
+
+  private
+
+  def calculate_sales_tax
+    return 0 if NON_TAXABLE.any? { |item| @name.include? item }
+
+    @cost * TAX_RATE / 100
+  end
+
+  def calculate_import_duty
+    return 0 unless IMPORTED.any? { |item| @name.include? item }
+
+    @cost * IMPORT_DUTY / 100
+  end
+
+  # round up to nearest 0.05
+  def round_up_to_nearest005(tax)
+    (tax * 20).ceil / 20.0
+  end
+end

--- a/lib/line_item.rb
+++ b/lib/line_item.rb
@@ -7,7 +7,7 @@ class LineItem
   NON_TAXABLE = %w[book chocolate chocolates pills].freeze
   IMPORTED = %w[imported].freeze
 
-  attr_reader :name, :quantity
+  attr_reader :name, :quantity, :shelf_price
 
   def initialize(quantity, name, shelf_price)
     @quantity = quantity

--- a/lib/receipt.rb
+++ b/lib/receipt.rb
@@ -6,7 +6,7 @@ class Receipt
     @line_items = line_items
   end
 
-  def data
+  def formatted_output
     receipt_data = ''
     total_sales_tax = 0
     total_cost = 0

--- a/lib/receipt.rb
+++ b/lib/receipt.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Returns the receipt
+class Receipt
+  def initialize(line_items = [])
+    @line_items = line_items
+  end
+
+  def data
+    receipt_data = ''
+    total_sales_tax = 0
+    total_cost = 0
+    @line_items.each do |line_item|
+      total_sales_tax += line_item.total_sales_tax
+      total_cost += line_item.total_cost.to_f
+      receipt_data += "#{line_item.quantity}, #{line_item.name}, #{line_item.total_cost}\n"
+    end
+
+    receipt_data += "\nSales Taxes: #{format('%.2f', total_sales_tax)}"
+    receipt_data += "\nTotal: #{format('%.2f', total_cost)}\n\n"
+
+    receipt_data
+  end
+end

--- a/lib/shopping_basket_parser.rb
+++ b/lib/shopping_basket_parser.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require './lib/line_item'
+
+# parse input string
+class ShoppingBasketParser
+  def initialize(shopping_basket)
+    @shopping_basket = shopping_basket
+  end
+
+  def parse
+    shopping_array = @shopping_basket.split("\n").compact
+
+    delete_header(shopping_array)
+
+    get_line_items(shopping_array)
+  end
+
+  private
+
+  def get_line_items(shopping_array)
+    shopping_array.map do |item|
+      quantity, name, shelf_price = item.strip.split(',').map(&:strip)
+
+      raise ArgumentError, 'Quantity is not numeric' if quantity !~ /^\d*$/
+      raise ArgumentError, 'Name is not a string' if name =~ /^[0-9]*$/
+      raise ArgumentError, 'Price is not float' if shelf_price !~ /^\d+\.\d\d$/
+
+      LineItem.new(quantity.to_i, name, shelf_price.to_f)
+    end
+  end
+
+  def delete_header(shopping_array)
+    raise ArgumentError, 'Header not supplied' unless shopping_array[0] == 'Quantity, Product, Price'
+
+    shopping_array.delete_at(0)
+  end
+end

--- a/spec/line_item_spec.rb
+++ b/spec/line_item_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require './lib/line_item'
+
+RSpec.describe LineItem do
+  subject(:total_cost) { line_item.total_cost }
+  subject(:total_sales_tax) { line_item.total_sales_tax }
+
+  describe '#total_cost' do
+    context 'when a non imported item is purchased' do
+      context 'when a book is purchased' do
+        let(:line_item) { LineItem.new(1, 'book', 12.49) }
+
+        it 'cost not changed' do
+          expect(total_cost.to_f).to eq 12.49
+        end
+
+        it 'sales tax is 0' do
+          expect(total_sales_tax).to eq 0
+        end
+      end
+
+      context 'when a music item is purchased' do
+        let(:line_item) { LineItem.new(1, 'music cd', 14.99) }
+
+        it 'adds sales tax to cost' do
+          expect(total_cost.to_f).to eq 16.49
+        end
+
+        it 'sales tax is non zero' do
+          expect(total_sales_tax).to eq 1.5
+        end
+      end
+
+      context 'when a food item is purchased' do
+        let(:line_item) { LineItem.new(1, 'chocolate bar', 0.85) }
+
+        it 'cost remains same' do
+          expect(total_cost.to_f).to eq 0.85
+        end
+
+        it 'sales tax is 0' do
+          expect(total_sales_tax).to eq 0
+        end
+      end
+
+      context 'when a medical item is purchased' do
+        let(:line_item) { LineItem.new(1, 'packet of headache pills', 9.75) }
+
+        it 'cost reamins same' do
+          expect(total_cost.to_f).to eq 9.75
+        end
+
+        it 'sales tax is 0' do
+          expect(total_sales_tax).to eq 0
+        end
+      end
+
+      context 'when passed a non handled value for tax exempt data' do
+        let(:line_item) { LineItem.new(1, 'box of biscuits', 14.99) }
+
+        it 'treated as a taxed input' do
+          expect(total_cost.to_f).to eq 16.49
+        end
+
+        it 'sales tax is non zero' do
+          expect(total_sales_tax).to eq 1.5
+        end
+      end
+    end
+
+    context 'when an imported item is purchased' do
+      context 'when the item is tax exempt' do
+        let(:line_item) { LineItem.new(1, 'imported box of chocolates', 10.00) }
+
+        it 'adds import duty to cost' do
+          expect(total_cost.to_f).to eq 10.50
+        end
+
+        it 'sales tax is 5% import duty' do
+          expect(total_sales_tax).to eq 0.5
+        end
+      end
+
+      context 'when the item is non tax exempt' do
+        let(:line_item) { LineItem.new(1, 'imported bottle of perfume', 47.50) }
+
+        it 'adds import duty and sales tax to cost' do
+          expect(total_cost.to_f).to eq 54.65
+        end
+
+        it 'sales tax is 10% plus 5% import duty' do
+          expect(total_sales_tax).to eq 7.15
+        end
+      end
+    end
+  end
+end

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -4,7 +4,7 @@ require './lib/receipt'
 require './lib/line_item'
 
 RSpec.describe Receipt do
-  describe '#data' do
+  describe '#formatted_output' do
     context 'when non-imported items are purchased' do
       let(:line_item1) { LineItem.new(1, 'book', 12.49) }
       let(:line_item2) { LineItem.new(1, 'music cd', 14.99) }
@@ -16,7 +16,7 @@ RSpec.describe Receipt do
       let(:receipt) { Receipt.new([line_item1, line_item2, line_item3]) }
 
       it 'returns the receipt with sales tax calculated' do
-        expect(receipt.data).to eq expected_output
+        expect(receipt.formatted_output).to eq expected_output
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe Receipt do
       let(:receipt) { Receipt.new([line_item1, line_item2]) }
 
       it 'adds import duty' do
-        expect(receipt.data).to eq expected_output
+        expect(receipt.formatted_output).to eq expected_output
       end
     end
   end
@@ -48,7 +48,7 @@ RSpec.describe Receipt do
     let(:receipt) { Receipt.new([line_item1, line_item2, line_item3, line_item4]) }
 
     it 'returns the receipt with appropriate sales tax and import duty' do
-      expect(receipt.data).to eq expected_output
+      expect(receipt.formatted_output).to eq expected_output
     end
   end
 end

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require './lib/receipt'
+require './lib/line_item'
+
+RSpec.describe Receipt do
+  describe '#data' do
+    context 'when non-imported items are purchased' do
+      let(:line_item1) { LineItem.new(1, 'book', 12.49) }
+      let(:line_item2) { LineItem.new(1, 'music cd', 14.99) }
+      let(:line_item3) { LineItem.new(1, 'chocolate bar', 0.85) }
+      let(:expected_output) do
+        "1, book, 12.49\n1, music cd, 16.49\n1, chocolate bar, 0.85\n\nSales Taxes: 1.50\nTotal: 29.83\n\n"
+      end
+
+      let(:receipt) { Receipt.new([line_item1, line_item2, line_item3]) }
+
+      it 'returns the receipt with sales tax calculated' do
+        expect(receipt.data).to eq expected_output
+      end
+    end
+
+    context 'when imported items are purchased' do
+      let(:line_item1) { LineItem.new(1, 'imported box of chocolates', 10.00) }
+      let(:line_item2) { LineItem.new(1, 'imported bottle of perfume', 47.50) }
+
+      let(:expected_output) do
+        "1, imported box of chocolates, 10.50\n1, imported bottle of perfume, 54.65\n\nSales Taxes: 7.65\nTotal: 65.15\n\n"
+      end
+
+      let(:receipt) { Receipt.new([line_item1, line_item2]) }
+
+      it 'adds import duty' do
+        expect(receipt.data).to eq expected_output
+      end
+    end
+  end
+
+  context 'when imported and other items are purchased' do
+    let(:line_item1) { LineItem.new(1, 'imported bottle of perfume', 27.99) }
+    let(:line_item2) { LineItem.new(1, 'bottle of perfume', 18.99) }
+    let(:line_item3) { LineItem.new(1, 'packet of headache pills', 9.75) }
+    let(:line_item4) { LineItem.new(1, 'imported box of chocolates', 11.25) }
+    let(:expected_output) do
+      "1, imported bottle of perfume, 32.19\n1, bottle of perfume, 20.89\n1, packet of headache pills, 9.75\n1, imported box of chocolates, 11.85\n\nSales Taxes: 6.70\nTotal: 74.68\n\n"
+    end
+
+    let(:receipt) { Receipt.new([line_item1, line_item2, line_item3, line_item4]) }
+
+    it 'returns the receipt with appropriate sales tax and import duty' do
+      expect(receipt.data).to eq expected_output
+    end
+  end
+end

--- a/spec/shopping_basket_parser_spec.rb
+++ b/spec/shopping_basket_parser_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require './lib/shopping_basket_parser'
+
+RSpec.describe ShoppingBasketParser do
+  let(:shopping_basket1) do
+    'Quantity, Product, Price
+    1, book, 12.49
+    1, music cd, 14.99
+    1, chocolate bar, 0.85'
+  end
+
+  let(:line_item1) { LineItem.new(quantity: 1, name: 'book', shelf_price: 12.49) }
+  let(:line_item2) { LineItem.new(quantity: 1, name: 'music cd', shelf_price: 14.99) }
+  let(:line_item3) { LineItem.new(quantity: 1, name: 'chocolate bar', shelf_price: 0.85) }
+
+  subject(:line_items) { ShoppingBasketParser.new(shopping_basket1).parse }
+
+  describe 'parse' do
+    it 'returns expected number of Line Items' do
+      expect(line_items.length).to eq 3
+    end
+
+    it 'returns objects of type LineItem' do
+      expect(line_items[0]).to be_an_instance_of(LineItem)
+      expect(line_items[1]).to be_an_instance_of(LineItem)
+      expect(line_items[2]).to be_an_instance_of(LineItem)
+    end
+
+    it 'returns expected values' do
+      expect(line_items[0]).to have_attributes(quantity: 1, name: 'book', shelf_price: 12.49)
+      expect(line_items[1]).to have_attributes(quantity: 1, name: 'music cd', shelf_price: 14.99)
+      expect(line_items[2]).to have_attributes(quantity: 1, name: 'chocolate bar', shelf_price: 0.85)
+    end
+
+    context 'exceptions' do
+      let(:shopping_basket_with_bad_name) do
+        'Quantity, Product, Price
+        1, 23, 12.49'
+      end
+
+      let(:shopping_basket_with_bad_quantity) do
+        'Quantity, Product, Price
+        q, book, 12.49'
+      end
+
+      let(:shopping_basket_with_bad_price) do
+        'Quantity, Product, Price
+        1, book, 1'
+      end
+
+      let(:shopping_basket_with_no_header) do
+        '1, book, 10.00'
+      end
+
+      subject(:parse_with_bad_name) { ShoppingBasketParser.new(shopping_basket_with_bad_name).parse }
+      subject(:parse_with_bad_quantity) { ShoppingBasketParser.new(shopping_basket_with_bad_quantity).parse }
+      subject(:parse_with_bad_price) { ShoppingBasketParser.new(shopping_basket_with_bad_price).parse }
+      subject(:parse_with_no_header) { ShoppingBasketParser.new(shopping_basket_with_no_header).parse }
+
+      it 'raises an exception if quantity is not string' do
+        expect { parse_with_bad_quantity }.to raise_error(ArgumentError, 'Quantity is not numeric')
+      end
+
+      it 'raises an exception if name is not string' do
+        expect { parse_with_bad_name }.to raise_error(ArgumentError, 'Name is not a string')
+      end
+
+      it 'raises an exception if price is not string' do
+        expect { parse_with_bad_price }.to raise_error(ArgumentError, 'Price is not float')
+      end
+
+      it 'raises an exception if header not supplied' do
+        expect { parse_with_no_header }.to raise_error(ArgumentError, 'Header not supplied')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pull request to generate receipt for a given shopping basket.
Input is passed as a string, which is then converted to line items. Sales tax is calculated on every line item and a receipt is generated.

Install dependencies: `gem install bundler && bundle install`.
Run `bundle exec rake` to generate the receipt for the given input.
Run `bundle exec rake test` to run tests.